### PR TITLE
ecs fargate add service registries

### DIFF
--- a/service_load_balancing/launch_type_fargate.tf
+++ b/service_load_balancing/launch_type_fargate.tf
@@ -1,5 +1,8 @@
 // NOTE: var.launch_type = "FARGATE" if you want use following
-
+locals {
+  enable_service_discovery = var.enable_service_discovery
+  service_discovery_registry_arn = var.enable_service_discovery && var.service_discovery_registry_arn != "" ? var.service_discovery_registry_arn : null
+}
 resource "aws_ecs_service" "fargate" {
   count = var.launch_type == "FARGATE" ? 1 : 0
 
@@ -25,6 +28,13 @@ resource "aws_ecs_service" "fargate" {
     target_group_arn = var.target_group_arn
     container_name   = var.container_name
     container_port   = var.container_port
+  }
+
+  dynamic "service_registries" {
+    for_each = local.enable_service_discovery ? [1] : []
+    content {
+      registry_arn   = local.service_discovery_registry_arn
+    }
   }
 
   lifecycle {

--- a/service_load_balancing/variables.tf
+++ b/service_load_balancing/variables.tf
@@ -273,3 +273,14 @@ variable "scale_in_step_adjustment" {
   }
 }
 
+variable "enable_service_discovery" {
+  description = "Determines whether to enable service discovery"
+  type        = bool
+  default     = false
+}
+
+variable "service_discovery_registry_arn" {
+  description = "The ARN of service discovery as arn:aws:servicediscovery:ap-northeast-1:xxxxxxxxx:service/srv-xxxxxxxxxxxxxxxxx"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Link: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#service_registries
What?: Add dynamic block service registries
Why?: In case we need to use service discovery